### PR TITLE
Stylelint rule updates

### DIFF
--- a/dotfiles/.stylelintrc
+++ b/dotfiles/.stylelintrc
@@ -1,18 +1,25 @@
 {
-  "extends": ["stylelint-config-standard"],
+  "extends": [
+    "stylelint-config-standard"
+  ],
   "plugins": [
     "stylelint-no-unsupported-browser-features",
-		"stylelint-scss"
+    "stylelint-scss"
   ],
   "rules": {
     "plugin/no-unsupported-browser-features": [
       true,
       {
-        "browsers": ["> 2%", "Last 2 versions", "ie >= 10", "not ie_mob < 11", "not op_mini all"],
+        "browsers": [
+          "> 2%",
+          "Last 2 versions",
+          "ie >= 10",
+          "not ie_mob < 11",
+          "not op_mini all"
+        ],
         "severity": "warning"
       }
     ],
-
     "color-no-invalid-hex": true,
     "font-family-no-duplicate-names": true,
     "font-family-no-missing-generic-family-keyword": true,
@@ -34,7 +41,28 @@
     "selector-pseudo-element-no-unknown": true,
     "selector-type-no-unknown": true,
     "media-feature-name-no-unknown": true,
-    "at-rule-no-unknown": true,
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "extend",
+          "at-root",
+          "debug",
+          "warn",
+          "error",
+          "if",
+          "else",
+          "for",
+          "each",
+          "while",
+          "mixin",
+          "include",
+          "content",
+          "return",
+          "function"
+        ]
+      }
+    ],
     "comment-no-empty": true,
     "no-descending-specificity": true,
     "no-duplicate-at-import-rules": true,
@@ -42,7 +70,6 @@
     "no-empty-source": true,
     "no-extra-semicolons": true,
     "no-invalid-double-slash-comments": null,
-
     "color-named": "never",
     "color-no-hex": null,
     "function-blacklist": null,
@@ -59,7 +86,7 @@
     "declaration-property-value-blacklist": null,
     "declaration-block-single-line-max-declarations": 1,
     "selector-attribute-operator-blacklist": null,
-		"selector-class-pattern": "^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$",
+    "selector-class-pattern": "^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$",
     "selector-combinator-blacklist": null,
     "selector-id-pattern": null,
     "selector-max-empty-lines": 0,
@@ -69,7 +96,10 @@
     "selector-no-qualifying-type": [
       true,
       {
-        ignore: ["attribute", "class"]
+        "ignore": [
+          "attribute",
+          "class"
+        ]
       }
     ],
     "selector-no-vendor-prefix": true,
@@ -99,10 +129,12 @@
     "value-list-max-empty-lines": 0,
     "custom-property-empty-line-before": [
       "always",
-      "except": [
-        "after-custom-property",
-        "first-nested"
-      ],
+      {
+        "except": [
+          "after-custom-property",
+          "first-nested"
+        ]
+      }
     ],
     "property-case": "lower",
     "declaration-bang-space-after": "never",
@@ -121,12 +153,15 @@
     ],
     "block-closing-brace-newline-after": [
       "always",
-      "ignoreAtRules": [
-        "if", "else"
-      ]
+      {
+        "ignoreAtRules": [
+          "if",
+          "else"
+        ]
+      }
     ],
     "block-closing-brace-space-after": "always-single-line",
-		"block-closing-brace-space-before": "always-single-line",
+    "block-closing-brace-space-before": "always-single-line",
     "block-opening-brace-space-after": "always-single-line",
     "block-opening-brace-space-before": "always",
     "block-opening-brace-newline-after": "always-multi-line",
@@ -149,10 +184,12 @@
     "selector-list-comma-space-before": "never",
     "rule-empty-line-before": [
       "always",
-      "except": [
-        "after-single-line-comment",
-        "first-nested"
-      ]
+      {
+        "except": [
+          "after-single-line-comment",
+          "first-nested"
+        ]
+      }
     ],
     "media-feature-colon-space-after": "always",
     "media-feature-colon-space-before": "never",
@@ -163,14 +200,17 @@
     "media-query-list-comma-space-before": "never",
     "at-rule-empty-line-before": [
       "always",
-      "except": [
-        "after-same-name",
-        "first-nested"
-      ], ignoreAtRules: [
-        "array",
-        "of",
-        "at-rules"
-      ]
+      {
+        "except": [
+          "after-same-name",
+          "first-nested"
+        ],
+        "ignoreAtRules": [
+          "array",
+          "of",
+          "at-rules"
+        ]
+      }
     ],
     "at-rule-name-case": "lower",
     "at-rule-name-space-after": "always",
@@ -180,7 +220,6 @@
     "indentation": 2,
     "max-empty-lines": 1,
     "no-eol-whitespace": true,
-
     "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
     "scss/at-else-closing-brace-space-after": "always-intermediate",
     "scss/at-else-empty-line-before": "never",


### PR DESCRIPTION
Убрал браузерcлист из настроек стайллинта, изменил следующие свойства:
```bash
120 | "value-list-comma-space-after": "always" на "never-single-line";
```
```bash
136 | "declaration-colon-space-after": "always" на "always-single-line";
```
Изменения пришлось внести так как текущие значения противоречат правилам:
```bash
119 | "value-list-comma-newline-after": "always-multi-line";
```
```bash
135 | "declaration-colon-newline-after": "always-multi-line";
```
 Из-за чего приходится писать значения свойств и список селекторов в одну строку что, как мне кажется, ухудшает читабельность кода. 